### PR TITLE
Rename offline_mall DB tables to winter_mall

### DIFF
--- a/classes/seeders/CategoryTableSeeder.php
+++ b/classes/seeders/CategoryTableSeeder.php
@@ -10,7 +10,7 @@ class CategoryTableSeeder extends Seeder
     public function run()
     {
         Category::extend(function () {
-            $this->setTable('offline_mall_categories');
+            $this->setTable('winter_mall_categories');
         }, true);
 
         $category       = new Category();

--- a/classes/seeders/NotificationTableSeeder.php
+++ b/classes/seeders/NotificationTableSeeder.php
@@ -10,7 +10,7 @@ class NotificationTableSeeder extends Seeder
     public function run()
     {
         Notification::extend(function () {
-            $this->setTable('offline_mall_notifications');
+            $this->setTable('winter_mall_notifications');
             $this->rules['code'] = str_replace('winter_', 'offline_', $this->rules['code']);
         }, true);
         Notification::create([

--- a/classes/seeders/OrderStateTableSeeder.php
+++ b/classes/seeders/OrderStateTableSeeder.php
@@ -36,13 +36,13 @@ class OrderStateTableSeeder extends Seeder
             }
 
             $s->forceFill(array_except($state, 'german_name'));
-            $s->setTable('offline_mall_order_states');
+            $s->setTable('winter_mall_order_states');
             $s->save();
 
             if ($isTranslatable) {
                 $s->translateContext('de');
                 $s->name = $state['german_name'];
-                $s->setTable('offline_mall_order_states');
+                $s->setTable('winter_mall_order_states');
                 $s->save();
             }
         }

--- a/classes/seeders/PaymentMethodTableSeeder.php
+++ b/classes/seeders/PaymentMethodTableSeeder.php
@@ -13,21 +13,21 @@ class PaymentMethodTableSeeder extends Seeder
         $method->name             = 'Stripe';
         $method->payment_provider = 'stripe';
         $method->sort_order       = 1;
-        $method->setTable('offline_mall_payment_methods');
+        $method->setTable('winter_mall_payment_methods');
         $method->save();
         
         $method                   = new PaymentMethod();
         $method->name             = 'PayPal';
         $method->payment_provider = 'paypal-rest';
         $method->sort_order       = 2;
-        $method->setTable('offline_mall_payment_methods');
+        $method->setTable('winter_mall_payment_methods');
         $method->save();
 
         $method                   = new PaymentMethod();
         $method->name             = 'Invoice';
         $method->payment_provider = 'offline';
         $method->sort_order       = 3;
-        $method->setTable('offline_mall_payment_methods');
+        $method->setTable('winter_mall_payment_methods');
         $method->save();
     }
 }

--- a/classes/seeders/PropertyTableSeeder.php
+++ b/classes/seeders/PropertyTableSeeder.php
@@ -15,21 +15,21 @@ class PropertyTableSeeder extends Seeder
         $method->name = 'Height';
         $method->type = 'text';
         $method->unit = 'mm';
-        $method->setTable('offline_mall_properties');
+        $method->setTable('winter_mall_properties');
         $method->save();
 
         $method       = new Property();
         $method->name = 'Width';
         $method->type = 'text';
         $method->unit = 'mm';
-        $method->setTable('offline_mall_properties');
+        $method->setTable('winter_mall_properties');
         $method->save();
 
         $method       = new Property();
         $method->name = 'Depth';
         $method->type = 'text';
         $method->unit = 'mm';
-        $method->setTable('offline_mall_properties');
+        $method->setTable('winter_mall_properties');
         $method->save();
 
         $method          = new Property();
@@ -42,26 +42,26 @@ class PropertyTableSeeder extends Seeder
             ['value' => 'L'],
             ['value' => 'XL'],
         ];
-        $method->setTable('offline_mall_properties');
+        $method->setTable('winter_mall_properties');
         $method->save();
 
         $propertyGroup = new PropertyGroup();
         $propertyGroup->name = 'Dimensions';
-        $propertyGroup->belongsToMany['properties']['table'] = 'offline_mall_property_property_group';
-        $propertyGroup->setTable('offline_mall_property_groups');
+        $propertyGroup->belongsToMany['properties']['table'] = 'winter_mall_property_property_group';
+        $propertyGroup->setTable('winter_mall_property_groups');
         $propertyGroup->save();
         $propertyGroup->properties()->attach([1, 2, 3]);
 
         $propertyGroup = new PropertyGroup();
         $propertyGroup->name = 'Size';
-        $propertyGroup->belongsToMany['properties']['table'] = 'offline_mall_property_property_group';
-        $propertyGroup->setTable('offline_mall_property_groups');
+        $propertyGroup->belongsToMany['properties']['table'] = 'winter_mall_property_property_group';
+        $propertyGroup->setTable('winter_mall_property_groups');
         $propertyGroup->save();
         $propertyGroup->properties()->attach([4]);
 
         Category::extend(function () {
-            $this->setTable('offline_mall_categories');
-            $this->belongsToMany['property_groups']['table'] = 'offline_mall_category_property_group';
+            $this->setTable('winter_mall_categories');
+            $this->belongsToMany['property_groups']['table'] = 'winter_mall_category_property_group';
         }, true);
 
         $category = Category::first();

--- a/classes/seeders/ShippingMethodTableSeeder.php
+++ b/classes/seeders/ShippingMethodTableSeeder.php
@@ -11,7 +11,7 @@ class ShippingMethodTableSeeder extends Seeder
     public function run()
     {
         $method             = new ShippingMethod();
-        $method->setTable('offline_mall_shipping_methods');
+        $method->setTable('winter_mall_shipping_methods');
         $method->name       = 'Default';
         $method->sort_order = 1;
         $method->save();
@@ -21,20 +21,20 @@ class ShippingMethodTableSeeder extends Seeder
             'currency_id'    => 1,
             'priceable_type' => ShippingMethod::MORPH_KEY,
             'priceable_id'   => $method->id,
-        ]))->setTable('offline_mall_prices')->save();
+        ]))->setTable('winter_mall_prices')->save();
 
         (new Price([
             'price'          => 12,
             'currency_id'    => 2,
             'priceable_type' => ShippingMethod::MORPH_KEY,
             'priceable_id'   => $method->id,
-        ]))->setTable('offline_mall_prices')->save();
+        ]))->setTable('winter_mall_prices')->save();
 
         (new Price([
             'price'          => 15,
             'currency_id'    => 3,
             'priceable_type' => ShippingMethod::MORPH_KEY,
             'priceable_id'   => $method->id,
-        ]))->setTable('offline_mall_prices')->save();
+        ]))->setTable('winter_mall_prices')->save();
     }
 }

--- a/classes/seeders/TaxTableSeeder.php
+++ b/classes/seeders/TaxTableSeeder.php
@@ -12,7 +12,7 @@ class TaxTableSeeder extends Seeder
         $method             = new Tax();
         $method->name       = 'Default';
         $method->percentage = 8;
-        $method->setTable('offline_mall_taxes');
+        $method->setTable('winter_mall_taxes');
         $method->save();
     }
 }

--- a/updates/add_brand_column_to_order_products_table.php
+++ b/updates/add_brand_column_to_order_products_table.php
@@ -8,14 +8,14 @@ class AddBrandColumnToOrderProductsTable extends Migration
 {
     public function up()
     {
-        Schema::table('offline_mall_order_products', function (Blueprint $table) {
+        Schema::table('winter_mall_order_products', function (Blueprint $table) {
             $table->text('brand')->after('variant_name')->nullable();
         });
     }
 
     public function down()
     {
-        Schema::table('offline_mall_order_products', function (Blueprint $table) {
+        Schema::table('winter_mall_order_products', function (Blueprint $table) {
             $table->dropColumn(['brand']);
         });
     }

--- a/updates/add_customer_group_id_to_rainlab_users.php
+++ b/updates/add_customer_group_id_to_rainlab_users.php
@@ -9,19 +9,19 @@ class AddCustomerGroupIdToRainlabUsers extends Migration
 
     public function up()
     {
-        if (Schema::hasColumn('users', 'offline_mall_customer_group_id')) {
+        if (Schema::hasColumn('users', 'winter_mall_customer_group_id')) {
             return;
         }
         Schema::table('users', function (Blueprint $table) {
-            $table->integer('offline_mall_customer_group_id')->nullable();
+            $table->integer('winter_mall_customer_group_id')->nullable();
         });
     }
 
     public function down()
     {
         Schema::table('users', function (Blueprint $table) {
-            if (Schema::hasColumn('users', 'offline_mall_customer_group_id')) {
-                $table->dropColumn(['offline_mall_customer_group_id']);
+            if (Schema::hasColumn('users', 'winter_mall_customer_group_id')) {
+                $table->dropColumn(['winter_mall_customer_group_id']);
             }
         });
     }

--- a/updates/add_description_columns_to_variants.php
+++ b/updates/add_description_columns_to_variants.php
@@ -7,7 +7,7 @@ class AddDescriptionColumnsToVariants extends Migration
 {
     public function up()
     {
-        Schema::table('offline_mall_product_variants', function ($table) {
+        Schema::table('winter_mall_product_variants', function ($table) {
             $table->string('description_short', 255)->nullable();
             $table->text('description')->nullable();
         });
@@ -15,7 +15,7 @@ class AddDescriptionColumnsToVariants extends Migration
 
     public function down()
     {
-        Schema::table('offline_mall_product_variants', function ($table) {
+        Schema::table('winter_mall_product_variants', function ($table) {
             $table->dropColumn(['description_short', 'description']);
         });
     }

--- a/updates/add_description_field_to_category.php
+++ b/updates/add_description_field_to_category.php
@@ -7,14 +7,14 @@ class AddDescriptionFieldToCategory extends Migration
 {
     public function up()
     {
-        Schema::table('offline_mall_categories', function ($table) {
+        Schema::table('winter_mall_categories', function ($table) {
             $table->text('description')->nullable();
         });
     }
 
     public function down()
     {
-        Schema::table('offline_mall_categories', function ($table) {
+        Schema::table('winter_mall_categories', function ($table) {
             $table->dropColumn(['description']);
         });
     }

--- a/updates/add_embeds_column_to_products_table.php
+++ b/updates/add_embeds_column_to_products_table.php
@@ -7,7 +7,7 @@ class AddEmbedsColumnToProductsTable extends Migration
 {
     public function up()
     {
-        Schema::table('offline_mall_products', function($table)
+        Schema::table('winter_mall_products', function($table)
         {
             $table->text('embeds')->nullable();
         });
@@ -15,7 +15,7 @@ class AddEmbedsColumnToProductsTable extends Migration
     
     public function down()
     {
-        Schema::table('offline_mall_products', function($table)
+        Schema::table('winter_mall_products', function($table)
         {
             $table->dropColumn('embeds');
         });

--- a/updates/add_google_category_id_to_categories_table.php
+++ b/updates/add_google_category_id_to_categories_table.php
@@ -8,14 +8,14 @@ class AddGoogleCategoryIdToCategoriesTable extends Migration
 {
     public function up()
     {
-        Schema::table('offline_mall_categories', function (Blueprint $table) {
+        Schema::table('winter_mall_categories', function (Blueprint $table) {
             $table->integer('google_product_category_id')->after('sort_order')->nullable();
         });
     }
 
     public function down()
     {
-        Schema::table('offline_mall_categories', function (Blueprint $table) {
+        Schema::table('winter_mall_categories', function (Blueprint $table) {
             $table->dropColumn(['google_product_category_id']);
         });
     }

--- a/updates/add_identifier_columns_for_products_and_variants.php
+++ b/updates/add_identifier_columns_for_products_and_variants.php
@@ -7,11 +7,11 @@ class AddIdentifierColumnsForProductsAndVariants extends Migration
 {
     public function up()
     {
-        Schema::table('offline_mall_products', function ($table) {
+        Schema::table('winter_mall_products', function ($table) {
             $table->string('mpn')->nullable();
             $table->string('gtin')->nullable();
         });
-        Schema::table('offline_mall_product_variants', function ($table) {
+        Schema::table('winter_mall_product_variants', function ($table) {
             $table->string('mpn')->nullable();
             $table->string('gtin')->nullable();
         });
@@ -19,10 +19,10 @@ class AddIdentifierColumnsForProductsAndVariants extends Migration
 
     public function down()
     {
-        Schema::table('offline_mall_products', function ($table) {
+        Schema::table('winter_mall_products', function ($table) {
             $table->dropColumn(['mpn', 'gtin']);
         });
-        Schema::table('offline_mall_product_variants', function ($table) {
+        Schema::table('winter_mall_product_variants', function ($table) {
             $table->dropColumn(['mpn', 'gtin']);
         });
     }

--- a/updates/add_is_default_column_to_taxes_table.php
+++ b/updates/add_is_default_column_to_taxes_table.php
@@ -7,7 +7,7 @@ class AddIsDefaultColumnToTaxesTable extends Migration
 {
     public function up()
     {
-        Schema::table('offline_mall_taxes', function($table)
+        Schema::table('winter_mall_taxes', function($table)
         {
             $table->boolean('is_default')->default(0);
         });
@@ -15,7 +15,7 @@ class AddIsDefaultColumnToTaxesTable extends Migration
     
     public function down()
     {
-        Schema::table('offline_mall_taxes', function($table)
+        Schema::table('winter_mall_taxes', function($table)
         {
             $table->dropColumn('is_default');
         });

--- a/updates/add_name_column_to_index_table.php
+++ b/updates/add_name_column_to_index_table.php
@@ -8,11 +8,11 @@ class AddNameColumnToIndexTable extends Migration
 {
     public function up()
     {
-        if ( ! Schema::hasTable('offline_mall_index')) {
+        if ( ! Schema::hasTable('winter_mall_index')) {
             return;
         }
-        Schema::table('offline_mall_index', function (Blueprint $table) {
-            if ( ! Schema::hasColumn('offline_mall_index', 'name')) {
+        Schema::table('winter_mall_index', function (Blueprint $table) {
+            if ( ! Schema::hasColumn('winter_mall_index', 'name')) {
                 $table->string('name', 191);
             }
         });

--- a/updates/add_payment_method_id_to_discounts_table.php
+++ b/updates/add_payment_method_id_to_discounts_table.php
@@ -9,14 +9,14 @@ class AddPaymentMethodIdToDiscountsTable extends Migration
 {
     public function up()
     {
-        Schema::table('offline_mall_discounts', function ($table) {
+        Schema::table('winter_mall_discounts', function ($table) {
             $table->integer('payment_method_id')->after('product_id')->nullable();
         });
     }
 
     public function down()
     {
-        Schema::table('offline_mall_discounts', function ($table) {
+        Schema::table('winter_mall_discounts', function ($table) {
             $table->dropColumn(['payment_method_id']);
         });
     }

--- a/updates/add_pdf_partial_to_payment_method.php
+++ b/updates/add_pdf_partial_to_payment_method.php
@@ -9,14 +9,14 @@ class AddPDFPartialToPaymentMethod extends Migration
 {
     public function up()
     {
-        Schema::table('offline_mall_payment_methods', function ($table) {
+        Schema::table('winter_mall_payment_methods', function ($table) {
             $table->string('pdf_partial')->after('fee_percentage')->nullable();
         });
     }
 
     public function down()
     {
-        Schema::table('offline_mall_payment_methods', function ($table) {
+        Schema::table('winter_mall_payment_methods', function ($table) {
             $table->dropColumn(['pdf_partial']);
         });
     }

--- a/updates/add_product_variants_sort_order.php
+++ b/updates/add_product_variants_sort_order.php
@@ -8,14 +8,14 @@ class AddProductVariantSortOrder extends Migration
 {
     public function up()
     {
-        Schema::table('offline_mall_product_variants', function (Blueprint $table) {
+        Schema::table('winter_mall_product_variants', function (Blueprint $table) {
             $table->unsignedinteger('sort_order')->nullable()->index();
         });
     }
 
     public function down()
     {
-        Schema::table('offline_mall_product_variants', function ($table) {
+        Schema::table('winter_mall_product_variants', function ($table) {
             $table->dropColumn('sort_order');
         });
     }

--- a/updates/add_rounding_column_to_currencies_table.php
+++ b/updates/add_rounding_column_to_currencies_table.php
@@ -7,7 +7,7 @@ class AddRoundingColumnToCurrenciesTable extends Migration
 {
     public function up()
     {
-        Schema::table('offline_mall_currencies', function($table)
+        Schema::table('winter_mall_currencies', function($table)
         {
             $table->integer('rounding')->nullable();
         });
@@ -15,7 +15,7 @@ class AddRoundingColumnToCurrenciesTable extends Migration
 
     public function down()
     {
-        Schema::table('offline_mall_currencies', function($table)
+        Schema::table('winter_mall_currencies', function($table)
         {
             $table->dropColumn('rounding');
         });

--- a/updates/add_shipping_method_id_to_wishlists_table.php
+++ b/updates/add_shipping_method_id_to_wishlists_table.php
@@ -8,14 +8,14 @@ class AddShippingMethodIdToWishlistsTable extends Migration
 {
     public function up()
     {
-        Schema::table('offline_mall_wishlists', function (Blueprint $table) {
+        Schema::table('winter_mall_wishlists', function (Blueprint $table) {
             $table->integer('shipping_method_id')->nullable();
         });
     }
 
     public function down()
     {
-        Schema::table('offline_mall_wishlists', function (Blueprint $table) {
+        Schema::table('winter_mall_wishlists', function (Blueprint $table) {
             $table->dropColumn(['shipping_method_id']);
         });
     }

--- a/updates/add_short_description_field_to_category.php
+++ b/updates/add_short_description_field_to_category.php
@@ -7,14 +7,14 @@ class AddShortDescriptionFieldToCategory extends Migration
 {
     public function up()
     {
-        Schema::table('offline_mall_categories', function ($table) {
+        Schema::table('winter_mall_categories', function ($table) {
             $table->string('description_short', 255)->nullable();
         });
     }
 
     public function down()
     {
-        Schema::table('offline_mall_categories', function ($table) {
+        Schema::table('winter_mall_categories', function ($table) {
             $table->dropColumn(['description_short']);
         });
     }

--- a/updates/add_user_belongs_to_group_discount.php
+++ b/updates/add_user_belongs_to_group_discount.php
@@ -7,14 +7,14 @@ class AddUserBelongsToGroupDiscount extends Migration
 {
     public function up()
     {
-        Schema::table('offline_mall_discounts', function ($table) {
+        Schema::table('winter_mall_discounts', function ($table) {
             $table->integer('customer_group_id')->unsigned()->nullable();
         });
     }
 
     public function down()
     {
-        Schema::table('offline_mall_discounts', function ($table) {
+        Schema::table('winter_mall_discounts', function ($table) {
             $table->dropColumn(['customer_group_id']);
         });
     }

--- a/updates/add_valid_from_column_to_discounts_table.php
+++ b/updates/add_valid_from_column_to_discounts_table.php
@@ -8,14 +8,14 @@ class AddValidFromColumnToDiscountsTable extends Migration
 {
     public function up()
     {
-        Schema::table('offline_mall_discounts', function (Blueprint $table) {
+        Schema::table('winter_mall_discounts', function (Blueprint $table) {
             $table->dateTime('valid_from')->after('max_number_of_usages')->nullable();
         });
     }
 
     public function down()
     {
-        Schema::table('offline_mall_discounts', function (Blueprint $table) {
+        Schema::table('winter_mall_discounts', function (Blueprint $table) {
             $table->dropColumn(['valid_from']);
         });
     }

--- a/updates/add_virtual_products_support.php
+++ b/updates/add_virtual_products_support.php
@@ -9,13 +9,13 @@ class AddVirtualProductsSupport extends Migration
 {
     public function up()
     {
-        Schema::table('offline_mall_products', function (Blueprint $table) {
+        Schema::table('winter_mall_products', function (Blueprint $table) {
             $table->boolean('is_virtual')->default(false);
             $table->integer('file_expires_after_days')->unsigned()->nullable();
             $table->integer('file_max_download_count')->unsigned()->nullable();
             $table->boolean('file_session_required')->default(0);
         });
-        Schema::create('offline_mall_product_files', function (Blueprint $table) {
+        Schema::create('winter_mall_product_files', function (Blueprint $table) {
             $table->engine = 'InnoDB';
             $table->increments('id')->unsigned();
             $table->integer('product_id')->unsigned();
@@ -25,7 +25,7 @@ class AddVirtualProductsSupport extends Migration
             $table->timestamp('created_at')->nullable();
             $table->timestamp('updated_at')->nullable();
         });
-        Schema::create('offline_mall_product_file_grants', function (Blueprint $table) {
+        Schema::create('winter_mall_product_file_grants', function (Blueprint $table) {
             $table->engine = 'InnoDB';
             $table->increments('id')->unsigned();
             $table->integer('order_product_id')->unsigned();
@@ -37,16 +37,16 @@ class AddVirtualProductsSupport extends Migration
             $table->timestamp('updated_at')->nullable();
             $table->timestamp('expires_at')->nullable();
         });
-        Schema::table('offline_mall_orders', function (Blueprint $table) {
+        Schema::table('winter_mall_orders', function (Blueprint $table) {
             $table->boolean('is_virtual')->default(0)->after('total_post_taxes');
             $table->date('paid_at')->nullable()->after('shipped_at');
         });
-        Schema::table('offline_mall_order_products', function (Blueprint $table) {
+        Schema::table('winter_mall_order_products', function (Blueprint $table) {
             $table->boolean('is_virtual')->default(0)->after('quantity');
         });
 
         Notification::extend(function () {
-            $this->setTable('offline_mall_notifications');
+            $this->setTable('winter_mall_notifications');
             $this->rules['code'] = str_replace('winter_', 'offline_', $this->rules['code']);
         }, true);
         Notification::create([
@@ -64,7 +64,7 @@ class AddVirtualProductsSupport extends Migration
 
     public function down()
     {
-        Schema::table('offline_mall_products', function (Blueprint $table) {
+        Schema::table('winter_mall_products', function (Blueprint $table) {
             $table->dropColumn([
                 'is_virtual',
                 'file_expires_after_days',
@@ -72,13 +72,13 @@ class AddVirtualProductsSupport extends Migration
                 'file_session_required',
             ]);
         });
-        Schema::table('offline_mall_orders', function (Blueprint $table) {
+        Schema::table('winter_mall_orders', function (Blueprint $table) {
             $table->dropColumn(['is_virtual', 'paid_at']);
         });
-        Schema::table('offline_mall_order_products', function (Blueprint $table) {
+        Schema::table('winter_mall_order_products', function (Blueprint $table) {
             $table->dropColumn(['is_virtual']);
         });
-        Schema::dropIfExists('offline_mall_product_files');
-        Schema::dropIfExists('offline_mall_product_file_grants');
+        Schema::dropIfExists('winter_mall_product_files');
+        Schema::dropIfExists('winter_mall_product_file_grants');
     }
 }

--- a/updates/add_width_and_length_to_product_model.php
+++ b/updates/add_width_and_length_to_product_model.php
@@ -7,12 +7,12 @@ class AddWidthAndLengthToProductModel extends Migration
 {
     public function up()
     {
-        Schema::table('offline_mall_products', function ($table) {
+        Schema::table('winter_mall_products', function ($table) {
             $table->integer('length')->after('weight')->unsigned()->nullable();
             $table->integer('width')->after('length')->unsigned()->nullable();
             $table->integer('height')->after('width')->unsigned()->nullable();
         });
-        Schema::table('offline_mall_product_variants', function ($table) {
+        Schema::table('winter_mall_product_variants', function ($table) {
             $table->integer('length')->after('weight')->unsigned()->nullable();
             $table->integer('width')->after('length')->unsigned()->nullable();
             $table->integer('height')->after('width')->unsigned()->nullable();
@@ -21,10 +21,10 @@ class AddWidthAndLengthToProductModel extends Migration
 
     public function down()
     {
-        Schema::table('offline_mall_products', function ($table) {
+        Schema::table('winter_mall_products', function ($table) {
             $table->dropColumn(['length', 'width', 'height']);
         });
-        Schema::table('offline_mall_product_variants', function ($table) {
+        Schema::table('winter_mall_product_variants', function ($table) {
             $table->dropColumn(['length', 'width', 'height']);
         });
     }

--- a/updates/create_offline_mall_addresses.php
+++ b/updates/create_offline_mall_addresses.php
@@ -7,7 +7,7 @@ class CreateOfflineMallAddresses extends Migration
 {
     public function up()
     {
-        Schema::create('offline_mall_addresses', function ($table) {
+        Schema::create('winter_mall_addresses', function ($table) {
             $table->engine = 'InnoDB';
             $table->increments('id')->unsigned();
             $table->string('company')->nullable();
@@ -27,6 +27,6 @@ class CreateOfflineMallAddresses extends Migration
 
     public function down()
     {
-        Schema::dropIfExists('offline_mall_addresses');
+        Schema::dropIfExists('winter_mall_addresses');
     }
 }

--- a/updates/create_offline_mall_brands.php
+++ b/updates/create_offline_mall_brands.php
@@ -7,7 +7,7 @@ class CreateOfflineMallBrands extends Migration
 {
     public function up()
     {
-        Schema::create('offline_mall_brands', function ($table) {
+        Schema::create('winter_mall_brands', function ($table) {
             $table->engine = 'InnoDB';
             $table->increments('id')->unsigned();
             $table->string('name');
@@ -22,6 +22,6 @@ class CreateOfflineMallBrands extends Migration
 
     public function down()
     {
-        Schema::dropIfExists('offline_mall_brands');
+        Schema::dropIfExists('winter_mall_brands');
     }
 }

--- a/updates/create_offline_mall_cart_custom_field_value.php
+++ b/updates/create_offline_mall_cart_custom_field_value.php
@@ -7,7 +7,7 @@ class CreateOfflineMallCartCustomFieldValue extends Migration
 {
     public function up()
     {
-        Schema::create('offline_mall_cart_custom_field_value', function ($table) {
+        Schema::create('winter_mall_cart_custom_field_value', function ($table) {
             $table->engine = 'InnoDB';
             $table->increments('id')->unsigned();
             $table->integer('cart_product_id')->unsigned()->nullable();
@@ -21,6 +21,6 @@ class CreateOfflineMallCartCustomFieldValue extends Migration
 
     public function down()
     {
-        Schema::dropIfExists('offline_mall_cart_custom_field_value');
+        Schema::dropIfExists('winter_mall_cart_custom_field_value');
     }
 }

--- a/updates/create_offline_mall_cart_discount.php
+++ b/updates/create_offline_mall_cart_discount.php
@@ -7,7 +7,7 @@ class CreateOfflineMallCartDiscount extends Migration
 {
     public function up()
     {
-        Schema::create('offline_mall_cart_discount', function ($table) {
+        Schema::create('winter_mall_cart_discount', function ($table) {
             $table->engine = 'InnoDB';
             $table->increments('id')->unsigned();
             $table->integer('cart_id')->unsigned();
@@ -21,6 +21,6 @@ class CreateOfflineMallCartDiscount extends Migration
     
     public function down()
     {
-        Schema::dropIfExists('offline_mall_cart_discount');
+        Schema::dropIfExists('winter_mall_cart_discount');
     }
 }

--- a/updates/create_offline_mall_cart_products.php
+++ b/updates/create_offline_mall_cart_products.php
@@ -7,7 +7,7 @@ class CreateOfflineMallCartProducts extends Migration
 {
     public function up()
     {
-        Schema::create('offline_mall_cart_products', function ($table) {
+        Schema::create('winter_mall_cart_products', function ($table) {
             $table->engine = 'InnoDB';
             $table->increments('id')->unsigned();
             $table->integer('cart_id')->unsigned()->nullable();
@@ -23,6 +23,6 @@ class CreateOfflineMallCartProducts extends Migration
 
     public function down()
     {
-        Schema::dropIfExists('offline_mall_cart_products');
+        Schema::dropIfExists('winter_mall_cart_products');
     }
 }

--- a/updates/create_offline_mall_carts.php
+++ b/updates/create_offline_mall_carts.php
@@ -7,7 +7,7 @@ class CreateOfflineMallCarts extends Migration
 {
     public function up()
     {
-        Schema::create('offline_mall_carts', function ($table) {
+        Schema::create('winter_mall_carts', function ($table) {
             $table->engine = 'InnoDB';
             $table->increments('id')->unsigned();
             $table->string('session_id')->nullable();
@@ -28,6 +28,6 @@ class CreateOfflineMallCarts extends Migration
 
     public function down()
     {
-        Schema::dropIfExists('offline_mall_carts');
+        Schema::dropIfExists('winter_mall_carts');
     }
 }

--- a/updates/create_offline_mall_categories.php
+++ b/updates/create_offline_mall_categories.php
@@ -7,7 +7,7 @@ class CreateOfflineMallCategories extends Migration
 {
     public function up()
     {
-        Schema::create('offline_mall_categories', function ($table) {
+        Schema::create('winter_mall_categories', function ($table) {
             $table->engine = 'InnoDB';
             $table->increments('id');
             $table->string('name', 255);
@@ -38,6 +38,6 @@ class CreateOfflineMallCategories extends Migration
 
     public function down()
     {
-        Schema::dropIfExists('offline_mall_categories');
+        Schema::dropIfExists('winter_mall_categories');
     }
 }

--- a/updates/create_offline_mall_category_product_sort_order.php
+++ b/updates/create_offline_mall_category_product_sort_order.php
@@ -7,7 +7,7 @@ class CreateOfflineMallCategoryProductSortOrder extends Migration
 {
     public function up()
     {
-        Schema::create('offline_mall_category_product_sort_order', function ($table) {
+        Schema::create('winter_mall_category_product_sort_order', function ($table) {
             $table->engine = 'InnoDB';
             $table->increments('id')->unsigned();
             $table->integer('product_id')->unsigned();
@@ -18,6 +18,6 @@ class CreateOfflineMallCategoryProductSortOrder extends Migration
 
     public function down()
     {
-        Schema::dropIfExists('offline_mall_category_product_sort_order');
+        Schema::dropIfExists('winter_mall_category_product_sort_order');
     }
 }

--- a/updates/create_offline_mall_category_property_group.php
+++ b/updates/create_offline_mall_category_property_group.php
@@ -7,7 +7,7 @@ class CreateOfflineMallCategoryPropertyGroup extends Migration
 {
     public function up()
     {
-        Schema::create('offline_mall_category_property_group', function ($table) {
+        Schema::create('winter_mall_category_property_group', function ($table) {
             $table->engine = 'InnoDB';
             $table->increments('id')->unsigned();
             $table->integer('category_id')->unsigned();
@@ -24,6 +24,6 @@ class CreateOfflineMallCategoryPropertyGroup extends Migration
 
     public function down()
     {
-        Schema::dropIfExists('offline_mall_category_property_group');
+        Schema::dropIfExists('winter_mall_category_property_group');
     }
 }

--- a/updates/create_offline_mall_country_tax.php
+++ b/updates/create_offline_mall_country_tax.php
@@ -7,7 +7,7 @@ class CreateOfflineMallCountryTax extends Migration
 {
     public function up()
     {
-        Schema::create('offline_mall_country_tax', function ($table) {
+        Schema::create('winter_mall_country_tax', function ($table) {
             $table->engine = 'InnoDB';
             $table->increments('id')->unsigned();
             $table->integer('country_id');
@@ -19,6 +19,6 @@ class CreateOfflineMallCountryTax extends Migration
     
     public function down()
     {
-        Schema::dropIfExists('offline_mall_country_tax');
+        Schema::dropIfExists('winter_mall_country_tax');
     }
 }

--- a/updates/create_offline_mall_currencies.php
+++ b/updates/create_offline_mall_currencies.php
@@ -7,7 +7,7 @@ class CreateOfflineMallCurrencies extends Migration
 {
     public function up()
     {
-        Schema::create('offline_mall_currencies', function ($table) {
+        Schema::create('winter_mall_currencies', function ($table) {
             $table->engine = 'InnoDB';
             $table->increments('id')->unsigned();
             $table->string('code');
@@ -23,6 +23,6 @@ class CreateOfflineMallCurrencies extends Migration
 
     public function down()
     {
-        Schema::dropIfExists('offline_mall_currencies');
+        Schema::dropIfExists('winter_mall_currencies');
     }
 }

--- a/updates/create_offline_mall_custom_field_options.php
+++ b/updates/create_offline_mall_custom_field_options.php
@@ -7,7 +7,7 @@ class CreateOfflineMallProductCustomFieldOptions extends Migration
 {
     public function up()
     {
-        Schema::create('offline_mall_custom_field_options', function ($table) {
+        Schema::create('winter_mall_custom_field_options', function ($table) {
             $table->engine = 'InnoDB';
             $table->increments('id')->unsigned();
             $table->integer('custom_field_id')->unsigned()->nullable();
@@ -20,6 +20,6 @@ class CreateOfflineMallProductCustomFieldOptions extends Migration
 
     public function down()
     {
-        Schema::dropIfExists('offline_mall_custom_field_options');
+        Schema::dropIfExists('winter_mall_custom_field_options');
     }
 }

--- a/updates/create_offline_mall_custom_fields.php
+++ b/updates/create_offline_mall_custom_fields.php
@@ -7,7 +7,7 @@ class CreateOfflineMallProductCustomFields extends Migration
 {
     public function up()
     {
-        Schema::create('offline_mall_custom_fields', function ($table) {
+        Schema::create('winter_mall_custom_fields', function ($table) {
             $table->engine = 'InnoDB';
             $table->increments('id')->unsigned();
             $table->string('name');
@@ -19,6 +19,6 @@ class CreateOfflineMallProductCustomFields extends Migration
 
     public function down()
     {
-        Schema::dropIfExists('offline_mall_custom_fields');
+        Schema::dropIfExists('winter_mall_custom_fields');
     }
 }

--- a/updates/create_offline_mall_customer_group_prices.php
+++ b/updates/create_offline_mall_customer_group_prices.php
@@ -7,7 +7,7 @@ class CreateOfflineMallCustomerGroupPrices extends Migration
 {
     public function up()
     {
-        Schema::create('offline_mall_customer_group_prices', function ($table) {
+        Schema::create('winter_mall_customer_group_prices', function ($table) {
             $table->engine = 'InnoDB';
             $table->increments('id')->unsigned();
             $table->integer('customer_group_id')->unsigned();
@@ -29,6 +29,6 @@ class CreateOfflineMallCustomerGroupPrices extends Migration
 
     public function down()
     {
-        Schema::dropIfExists('offline_mall_customer_group_prices');
+        Schema::dropIfExists('winter_mall_customer_group_prices');
     }
 }

--- a/updates/create_offline_mall_customer_groups.php
+++ b/updates/create_offline_mall_customer_groups.php
@@ -7,7 +7,7 @@ class CreateOfflineMallCustomerGroups extends Migration
 {
     public function up()
     {
-        Schema::create('offline_mall_customer_groups', function ($table) {
+        Schema::create('winter_mall_customer_groups', function ($table) {
             $table->engine = 'InnoDB';
             $table->increments('id')->unsigned();
             $table->string('name');
@@ -21,6 +21,6 @@ class CreateOfflineMallCustomerGroups extends Migration
     
     public function down()
     {
-        Schema::dropIfExists('offline_mall_customer_groups');
+        Schema::dropIfExists('winter_mall_customer_groups');
     }
 }

--- a/updates/create_offline_mall_customer_payment_methods.php
+++ b/updates/create_offline_mall_customer_payment_methods.php
@@ -7,7 +7,7 @@ class CreateOfflineMallCustomerPaymentMethods extends Migration
 {
     public function up()
     {
-        Schema::create('offline_mall_customer_payment_methods', function ($table) {
+        Schema::create('winter_mall_customer_payment_methods', function ($table) {
             $table->engine = 'InnoDB';
             $table->increments('id')->unsigned();
             $table->string('name')->nullabe();
@@ -19,27 +19,27 @@ class CreateOfflineMallCustomerPaymentMethods extends Migration
             $table->timestamp('updated_at')->nullable();
             $table->timestamp('deleted_at')->nullable();
         });
-        Schema::table('offline_mall_orders', function ($table) {
+        Schema::table('winter_mall_orders', function ($table) {
             $table->integer('customer_payment_method_id')->nullable();
         });
-        Schema::table('offline_mall_carts', function ($table) {
+        Schema::table('winter_mall_carts', function ($table) {
             $table->integer('customer_payment_method_id')->nullable();
         });
-        Schema::table('offline_mall_customers', function ($table) {
+        Schema::table('winter_mall_customers', function ($table) {
             $table->string('stripe_customer_id')->nullable();
         });
     }
 
     public function down()
     {
-        Schema::dropIfExists('offline_mall_customer_payment_methods');
-        Schema::table('offline_mall_orders', function ($table) {
+        Schema::dropIfExists('winter_mall_customer_payment_methods');
+        Schema::table('winter_mall_orders', function ($table) {
             $table->dropColumn(['customer_payment_method_id']);
         });
-        Schema::table('offline_mall_carts', function ($table) {
+        Schema::table('winter_mall_carts', function ($table) {
             $table->dropColumn(['customer_payment_method_id']);
         });
-        Schema::table('offline_mall_customers', function ($table) {
+        Schema::table('winter_mall_customers', function ($table) {
             $table->dropColumn(['stripe_customer_id']);
         });
     }

--- a/updates/create_offline_mall_customers.php
+++ b/updates/create_offline_mall_customers.php
@@ -7,7 +7,7 @@ class CreateOfflineMallCustomers extends Migration
 {
     public function up()
     {
-        Schema::create('offline_mall_customers', function ($table) {
+        Schema::create('winter_mall_customers', function ($table) {
             $table->engine = 'InnoDB';
             $table->increments('id')->unsigned();
             $table->string('firstname');
@@ -24,6 +24,6 @@ class CreateOfflineMallCustomers extends Migration
 
     public function down()
     {
-        Schema::dropIfExists('offline_mall_customers');
+        Schema::dropIfExists('winter_mall_customers');
     }
 }

--- a/updates/create_offline_mall_discounts.php
+++ b/updates/create_offline_mall_discounts.php
@@ -7,7 +7,7 @@ class CreateOfflineMallDiscounts extends Migration
 {
     public function up()
     {
-        Schema::create('offline_mall_discounts', function ($table) {
+        Schema::create('winter_mall_discounts', function ($table) {
             $table->engine = 'InnoDB';
             $table->increments('id')->unsigned();
             $table->string('name');
@@ -28,6 +28,6 @@ class CreateOfflineMallDiscounts extends Migration
 
     public function down()
     {
-        Schema::dropIfExists('offline_mall_discounts');
+        Schema::dropIfExists('winter_mall_discounts');
     }
 }

--- a/updates/create_offline_mall_image_sets.php
+++ b/updates/create_offline_mall_image_sets.php
@@ -7,7 +7,7 @@ class CreateOfflineMallImageSets extends Migration
 {
     public function up()
     {
-        Schema::create('offline_mall_image_sets', function ($table) {
+        Schema::create('winter_mall_image_sets', function ($table) {
             $table->engine = 'InnoDB';
             $table->increments('id')->unsigned();
             $table->string('name')->nullable();
@@ -20,6 +20,6 @@ class CreateOfflineMallImageSets extends Migration
 
     public function down()
     {
-        Schema::dropIfExists('offline_mall_image_sets');
+        Schema::dropIfExists('winter_mall_image_sets');
     }
 }

--- a/updates/create_offline_mall_notifications.php
+++ b/updates/create_offline_mall_notifications.php
@@ -7,7 +7,7 @@ class CreateOfflineMallNotifications extends Migration
 {
     public function up()
     {
-        Schema::create('offline_mall_notifications', function ($table) {
+        Schema::create('winter_mall_notifications', function ($table) {
             $table->engine = 'InnoDB';
             $table->increments('id')->unsigned();
             $table->boolean('enabled')->default(1);
@@ -23,6 +23,6 @@ class CreateOfflineMallNotifications extends Migration
     
     public function down()
     {
-        Schema::dropIfExists('offline_mall_notifications');
+        Schema::dropIfExists('winter_mall_notifications');
     }
 }

--- a/updates/create_offline_mall_order_products.php
+++ b/updates/create_offline_mall_order_products.php
@@ -7,7 +7,7 @@ class CreateOfflineMallOrderProducts extends Migration
 {
     public function up()
     {
-        Schema::create('offline_mall_order_products', function ($table) {
+        Schema::create('winter_mall_order_products', function ($table) {
             $table->engine = 'InnoDB';
             $table->increments('id')->unsigned();
             $table->integer('order_id');
@@ -51,6 +51,6 @@ class CreateOfflineMallOrderProducts extends Migration
 
     public function down()
     {
-        Schema::dropIfExists('offline_mall_order_products');
+        Schema::dropIfExists('winter_mall_order_products');
     }
 }

--- a/updates/create_offline_mall_order_states.php
+++ b/updates/create_offline_mall_order_states.php
@@ -7,7 +7,7 @@ class CreateOfflineMallOrderStates extends Migration
 {
     public function up()
     {
-        Schema::create('offline_mall_order_states', function ($table) {
+        Schema::create('winter_mall_order_states', function ($table) {
             $table->engine = 'InnoDB';
             $table->increments('id')->unsigned();
             $table->string('name');
@@ -23,6 +23,6 @@ class CreateOfflineMallOrderStates extends Migration
 
     public function down()
     {
-        Schema::dropIfExists('offline_mall_order_states');
+        Schema::dropIfExists('winter_mall_order_states');
     }
 }

--- a/updates/create_offline_mall_orders.php
+++ b/updates/create_offline_mall_orders.php
@@ -7,7 +7,7 @@ class CreateOfflineMallOrders extends Migration
 {
     public function up()
     {
-        Schema::create('offline_mall_orders', function ($table) {
+        Schema::create('winter_mall_orders', function ($table) {
             $table->engine = 'InnoDB';
             $table->increments('id')->unsigned();
             $table->string('session_id')->nullable();
@@ -62,6 +62,6 @@ class CreateOfflineMallOrders extends Migration
 
     public function down()
     {
-        Schema::dropIfExists('offline_mall_orders');
+        Schema::dropIfExists('winter_mall_orders');
     }
 }

--- a/updates/create_offline_mall_payment_method_tax.php
+++ b/updates/create_offline_mall_payment_method_tax.php
@@ -7,7 +7,7 @@ class CreateOfflineMallPaymentMethodTax extends Migration
 {
     public function up()
     {
-        Schema::create('offline_mall_payment_method_tax', function ($table) {
+        Schema::create('winter_mall_payment_method_tax', function ($table) {
             $table->engine = 'InnoDB';
             $table->increments('id')->unsigned();
             $table->integer('payment_method_id')->unsigned();
@@ -19,6 +19,6 @@ class CreateOfflineMallPaymentMethodTax extends Migration
     
     public function down()
     {
-        Schema::dropIfExists('offline_mall_payment_method_tax');
+        Schema::dropIfExists('winter_mall_payment_method_tax');
     }
 }

--- a/updates/create_offline_mall_payment_methods.php
+++ b/updates/create_offline_mall_payment_methods.php
@@ -7,7 +7,7 @@ class CreateOfflineMallPaymentMethods extends Migration
 {
     public function up()
     {
-        Schema::create('offline_mall_payment_methods', function ($table) {
+        Schema::create('winter_mall_payment_methods', function ($table) {
             $table->engine = 'InnoDB';
             $table->increments('id')->unsigned();
             $table->string('name');
@@ -26,6 +26,6 @@ class CreateOfflineMallPaymentMethods extends Migration
 
     public function down()
     {
-        Schema::dropIfExists('offline_mall_payment_methods');
+        Schema::dropIfExists('winter_mall_payment_methods');
     }
 }

--- a/updates/create_offline_mall_payments_log.php
+++ b/updates/create_offline_mall_payments_log.php
@@ -7,7 +7,7 @@ class CreateOfflineMallPaymentsLog extends Migration
 {
     public function up()
     {
-        Schema::create('offline_mall_payments_log', function ($table) {
+        Schema::create('winter_mall_payments_log', function ($table) {
             $table->engine = 'InnoDB';
             $table->increments('id')->unsigned();
             $table->string('reference');
@@ -28,6 +28,6 @@ class CreateOfflineMallPaymentsLog extends Migration
 
     public function down()
     {
-        Schema::dropIfExists('offline_mall_payments_log');
+        Schema::dropIfExists('winter_mall_payments_log');
     }
 }

--- a/updates/create_offline_mall_price_categories.php
+++ b/updates/create_offline_mall_price_categories.php
@@ -7,7 +7,7 @@ class CreateOfflineMallPriceCategories extends Migration
 {
     public function up()
     {
-        Schema::create('offline_mall_price_categories', function ($table) {
+        Schema::create('winter_mall_price_categories', function ($table) {
             $table->engine = 'InnoDB';
             $table->increments('id')->unsigned();
             $table->string('name');
@@ -19,6 +19,6 @@ class CreateOfflineMallPriceCategories extends Migration
 
     public function down()
     {
-        Schema::dropIfExists('offline_mall_price_categories');
+        Schema::dropIfExists('winter_mall_price_categories');
     }
 }

--- a/updates/create_offline_mall_prices.php
+++ b/updates/create_offline_mall_prices.php
@@ -7,7 +7,7 @@ class CreateOfflineMallPrices extends Migration
 {
     public function up()
     {
-        Schema::create('offline_mall_prices', function ($table) {
+        Schema::create('winter_mall_prices', function ($table) {
             $table->engine = 'InnoDB';
             $table->increments('id')->unsigned();
             $table->integer('currency_id')->unsigned();
@@ -31,6 +31,6 @@ class CreateOfflineMallPrices extends Migration
 
     public function down()
     {
-        Schema::dropIfExists('offline_mall_prices');
+        Schema::dropIfExists('winter_mall_prices');
     }
 }

--- a/updates/create_offline_mall_product_accessory.php
+++ b/updates/create_offline_mall_product_accessory.php
@@ -7,7 +7,7 @@ class CreateOfflineMallProductAccessory extends Migration
 {
     public function up()
     {
-        Schema::create('offline_mall_product_accessory', function ($table) {
+        Schema::create('winter_mall_product_accessory', function ($table) {
             $table->engine = 'InnoDB';
             $table->increments('id')->unsigned();
             $table->integer('product_id')->unsigned();
@@ -17,6 +17,6 @@ class CreateOfflineMallProductAccessory extends Migration
 
     public function down()
     {
-        Schema::dropIfExists('offline_mall_product_accessory');
+        Schema::dropIfExists('winter_mall_product_accessory');
     }
 }

--- a/updates/create_offline_mall_product_custom_field.php
+++ b/updates/create_offline_mall_product_custom_field.php
@@ -7,7 +7,7 @@ class CreateOfflineMallProductCustomField extends Migration
 {
     public function up()
     {
-        Schema::create('offline_mall_product_custom_field', function ($table) {
+        Schema::create('winter_mall_product_custom_field', function ($table) {
             $table->engine = 'InnoDB';
             $table->increments('id')->unsigned();
             $table->integer('product_id')->unsigned();
@@ -17,6 +17,6 @@ class CreateOfflineMallProductCustomField extends Migration
     
     public function down()
     {
-        Schema::dropIfExists('offline_mall_product_custom_field');
+        Schema::dropIfExists('winter_mall_product_custom_field');
     }
 }

--- a/updates/create_offline_mall_product_prices.php
+++ b/updates/create_offline_mall_product_prices.php
@@ -7,7 +7,7 @@ class CreateOfflineMallProductPrices extends Migration
 {
     public function up()
     {
-        Schema::create('offline_mall_product_prices', function ($table) {
+        Schema::create('winter_mall_product_prices', function ($table) {
             $table->engine = 'InnoDB';
             $table->increments('id')->unsigned();
             $table->integer('price')->nullable();
@@ -27,6 +27,6 @@ class CreateOfflineMallProductPrices extends Migration
 
     public function down()
     {
-        Schema::dropIfExists('offline_mall_product_prices');
+        Schema::dropIfExists('winter_mall_product_prices');
     }
 }

--- a/updates/create_offline_mall_product_tax.php
+++ b/updates/create_offline_mall_product_tax.php
@@ -8,7 +8,7 @@ class CreateOfflineMallProductTax extends Migration
 {
     public function up()
     {
-        Schema::create('offline_mall_product_tax', function (Blueprint $table) {
+        Schema::create('winter_mall_product_tax', function (Blueprint $table) {
             $table->engine = 'InnoDB';
             $table->increments('id')->unsigned();
             $table->integer('tax_id');
@@ -20,6 +20,6 @@ class CreateOfflineMallProductTax extends Migration
 
     public function down()
     {
-        Schema::dropIfExists('offline_mall_product_tax');
+        Schema::dropIfExists('winter_mall_product_tax');
     }
 }

--- a/updates/create_offline_mall_product_variants.php
+++ b/updates/create_offline_mall_product_variants.php
@@ -7,7 +7,7 @@ class CreateOfflineMallProductVariants extends Migration
 {
     public function up()
     {
-        Schema::create('offline_mall_product_variants', function ($table) {
+        Schema::create('winter_mall_product_variants', function ($table) {
             $table->engine = 'InnoDB';
             $table->increments('id')->unsigned();
             $table->integer('product_id')->unsigned();
@@ -31,6 +31,6 @@ class CreateOfflineMallProductVariants extends Migration
 
     public function down()
     {
-        Schema::dropIfExists('offline_mall_product_variants');
+        Schema::dropIfExists('winter_mall_product_variants');
     }
 }

--- a/updates/create_offline_mall_products.php
+++ b/updates/create_offline_mall_products.php
@@ -7,7 +7,7 @@ class CreateOfflineMallProducts extends Migration
 {
     public function up()
     {
-        Schema::create('offline_mall_products', function ($table) {
+        Schema::create('winter_mall_products', function ($table) {
             $table->engine = 'InnoDB';
             $table->increments('id')->unsigned();
             $table->integer('category_id')->nullable();
@@ -50,6 +50,6 @@ class CreateOfflineMallProducts extends Migration
 
     public function down()
     {
-        Schema::dropIfExists('offline_mall_products');
+        Schema::dropIfExists('winter_mall_products');
     }
 }

--- a/updates/create_offline_mall_properties.php
+++ b/updates/create_offline_mall_properties.php
@@ -7,7 +7,7 @@ class CreateOfflineMallProperties extends Migration
 {
     public function up()
     {
-        Schema::create('offline_mall_properties', function ($table) {
+        Schema::create('winter_mall_properties', function ($table) {
             $table->engine = 'InnoDB';
             $table->increments('id')->unsigned();
             $table->string('name');
@@ -27,6 +27,6 @@ class CreateOfflineMallProperties extends Migration
 
     public function down()
     {
-        Schema::dropIfExists('offline_mall_properties');
+        Schema::dropIfExists('winter_mall_properties');
     }
 }

--- a/updates/create_offline_mall_property_groups.php
+++ b/updates/create_offline_mall_property_groups.php
@@ -7,7 +7,7 @@ class CreateOfflineMallPropertyGroups extends Migration
 {
     public function up()
     {
-        Schema::create('offline_mall_property_groups', function ($table) {
+        Schema::create('winter_mall_property_groups', function ($table) {
             $table->engine = 'InnoDB';
             $table->increments('id')->unsigned();
             $table->string('name');
@@ -22,6 +22,6 @@ class CreateOfflineMallPropertyGroups extends Migration
 
     public function down()
     {
-        Schema::dropIfExists('offline_mall_property_groups');
+        Schema::dropIfExists('winter_mall_property_groups');
     }
 }

--- a/updates/create_offline_mall_property_property_group.php
+++ b/updates/create_offline_mall_property_property_group.php
@@ -7,7 +7,7 @@ class CreateOfflineMallPropertyPropertyGroup extends Migration
 {
     public function up()
     {
-        Schema::create('offline_mall_property_property_group', function ($table) {
+        Schema::create('winter_mall_property_property_group', function ($table) {
             $table->engine = 'InnoDB';
             $table->increments('id')->unsigned();
             $table->integer('property_id')->unsigned();
@@ -22,6 +22,6 @@ class CreateOfflineMallPropertyPropertyGroup extends Migration
     
     public function down()
     {
-        Schema::dropIfExists('offline_mall_property_property_group');
+        Schema::dropIfExists('winter_mall_property_property_group');
     }
 }

--- a/updates/create_offline_mall_property_values.php
+++ b/updates/create_offline_mall_property_values.php
@@ -8,7 +8,7 @@ class CreateOfflineMallPropertyValues extends Migration
 {
     public function up()
     {
-        Schema::create('offline_mall_property_values', function ($table) {
+        Schema::create('winter_mall_property_values', function ($table) {
             $table->engine = 'InnoDB';
             $table->increments('id')->unsigned();
             $table->integer('product_id')->unsigned();
@@ -35,6 +35,6 @@ class CreateOfflineMallPropertyValues extends Migration
 
     public function down()
     {
-        Schema::dropIfExists('offline_mall_property_values');
+        Schema::dropIfExists('winter_mall_property_values');
     }
 }

--- a/updates/create_offline_mall_reviews.php
+++ b/updates/create_offline_mall_reviews.php
@@ -7,7 +7,7 @@ class CreateOfflineMallReviews extends Migration
 {
     public function up()
     {
-        Schema::create('offline_mall_review_categories', function ($table) {
+        Schema::create('winter_mall_review_categories', function ($table) {
             $table->engine = 'InnoDB';
             $table->increments('id')->unsigned();
             $table->string('name');
@@ -15,7 +15,7 @@ class CreateOfflineMallReviews extends Migration
             $table->timestamp('created_at')->nullable();
             $table->timestamp('updated_at')->nullable();
         });
-        Schema::create('offline_mall_category_review_category', function ($table) {
+        Schema::create('winter_mall_category_review_category', function ($table) {
             $table->engine = 'InnoDB';
             $table->increments('id')->unsigned();
             $table->integer('category_id');
@@ -26,7 +26,7 @@ class CreateOfflineMallReviews extends Migration
             $table->unique(['category_id', 'review_category_id'], 'unq_review_category_id');
             $table->index(['category_id', 'review_category_id'], 'idx_review_category_id');
         });
-        Schema::create('offline_mall_reviews', function ($table) {
+        Schema::create('winter_mall_reviews', function ($table) {
             $table->engine = 'InnoDB';
             $table->increments('id')->unsigned();
             $table->integer('product_id')->index();
@@ -42,7 +42,7 @@ class CreateOfflineMallReviews extends Migration
             $table->timestamp('updated_at')->nullable();
             $table->timestamp('approved_at')->nullable();
         });
-        Schema::create('offline_mall_category_reviews', function ($table) {
+        Schema::create('winter_mall_category_reviews', function ($table) {
             $table->engine = 'InnoDB';
             $table->increments('id')->unsigned();
             $table->integer('review_id')->index();
@@ -52,7 +52,7 @@ class CreateOfflineMallReviews extends Migration
             $table->timestamp('updated_at')->nullable();
             $table->timestamp('approved_at')->nullable();
         });
-        Schema::create('offline_mall_category_review_totals', function ($table) {
+        Schema::create('winter_mall_category_review_totals', function ($table) {
             $table->engine = 'InnoDB';
             $table->increments('id')->unsigned();
             $table->integer('product_id')->nullable()->index();
@@ -60,20 +60,20 @@ class CreateOfflineMallReviews extends Migration
             $table->integer('review_category_id');
             $table->decimal('rating', 3, 2);
         });
-        Schema::table('offline_mall_categories', function ($table) {
-            if ( ! Schema::hasColumn('offline_mall_categories', 'inherit_review_categories')) {
+        Schema::table('winter_mall_categories', function ($table) {
+            if ( ! Schema::hasColumn('winter_mall_categories', 'inherit_review_categories')) {
                 $table->boolean('inherit_review_categories')->after('inherit_property_groups')->default(0);
             }
         });
-        Schema::table('offline_mall_products', function ($table) {
+        Schema::table('winter_mall_products', function ($table) {
             $table->decimal('reviews_rating', 3, 2)->after('stock')->default(0);
         });
-        Schema::table('offline_mall_product_variants', function ($table) {
+        Schema::table('winter_mall_product_variants', function ($table) {
             $table->decimal('reviews_rating', 3, 2)->after('stock')->default(0);
         });
-        if (Schema::hasTable('offline_mall_index')) {
-            Schema::table('offline_mall_index', function ($table) {
-                if ( ! Schema::hasColumn('offline_mall_index', 'reviews_rating')) {
+        if (Schema::hasTable('winter_mall_index')) {
+            Schema::table('winter_mall_index', function ($table) {
+                if ( ! Schema::hasColumn('winter_mall_index', 'reviews_rating')) {
                     $table->decimal('reviews_rating', 3, 2);
                 }
             });
@@ -82,18 +82,18 @@ class CreateOfflineMallReviews extends Migration
 
     public function down()
     {
-        Schema::dropIfExists('offline_mall_review_categories');
-        Schema::dropIfExists('offline_mall_category_review_category');
-        Schema::dropIfExists('offline_mall_reviews');
-        Schema::dropIfExists('offline_mall_category_reviews');
-        Schema::dropIfExists('offline_mall_category_review_totals');
-        Schema::table('offline_mall_categories', function ($table) {
+        Schema::dropIfExists('winter_mall_review_categories');
+        Schema::dropIfExists('winter_mall_category_review_category');
+        Schema::dropIfExists('winter_mall_reviews');
+        Schema::dropIfExists('winter_mall_category_reviews');
+        Schema::dropIfExists('winter_mall_category_review_totals');
+        Schema::table('winter_mall_categories', function ($table) {
             $table->dropColumn(['inherit_review_categories']);
         });
-        Schema::table('offline_mall_products', function ($table) {
+        Schema::table('winter_mall_products', function ($table) {
             $table->dropColumn(['reviews_rating']);
         });
-        Schema::table('offline_mall_product_variants', function ($table) {
+        Schema::table('winter_mall_product_variants', function ($table) {
             $table->dropColumn(['reviews_rating']);
         });
     }

--- a/updates/create_offline_mall_services.php
+++ b/updates/create_offline_mall_services.php
@@ -7,7 +7,7 @@ class CreateOfflineMallServices extends Migration
 {
     public function up()
     {
-        Schema::create('offline_mall_services', function ($table) {
+        Schema::create('winter_mall_services', function ($table) {
             $table->engine = 'InnoDB';
             $table->increments('id')->unsigned();
             $table->string('name');
@@ -17,7 +17,7 @@ class CreateOfflineMallServices extends Migration
             $table->timestamp('updated_at')->nullable();
             $table->timestamp('deleted_at')->nullable();
         });
-        Schema::create('offline_mall_service_options', function ($table) {
+        Schema::create('winter_mall_service_options', function ($table) {
             $table->engine = 'InnoDB';
             $table->increments('id')->unsigned();
             $table->integer('service_id')->index()->nullable();
@@ -28,7 +28,7 @@ class CreateOfflineMallServices extends Migration
             $table->timestamp('updated_at')->nullable();
             $table->timestamp('deleted_at')->nullable();
         });
-        Schema::create('offline_mall_product_service', function ($table) {
+        Schema::create('winter_mall_product_service', function ($table) {
             $table->engine = 'InnoDB';
             $table->increments('id')->unsigned();
             $table->integer('service_id');
@@ -38,7 +38,7 @@ class CreateOfflineMallServices extends Migration
             $table->unique(['service_id', 'product_id']);
             $table->index(['service_id', 'product_id']);
         });
-        Schema::create('offline_mall_cart_product_service_option', function ($table) {
+        Schema::create('winter_mall_cart_product_service_option', function ($table) {
             $table->engine = 'InnoDB';
             $table->increments('id')->unsigned();
             $table->integer('service_option_id');
@@ -47,7 +47,7 @@ class CreateOfflineMallServices extends Migration
             $table->unique(['cart_product_id', 'service_option_id'], 'unq_cart_product_service_option');
             $table->index(['cart_product_id', 'service_option_id'], 'idx_cart_product_service_option');
         });
-        Schema::create('offline_mall_service_tax', function ($table) {
+        Schema::create('winter_mall_service_tax', function ($table) {
             $table->engine = 'InnoDB';
             $table->increments('id')->unsigned();
             $table->integer('tax_id')->index();
@@ -56,19 +56,19 @@ class CreateOfflineMallServices extends Migration
             $table->unique(['service_id', 'tax_id']);
             $table->index(['service_id', 'tax_id']);
         });
-        Schema::table('offline_mall_order_products', function ($table) {
+        Schema::table('winter_mall_order_products', function ($table) {
             $table->text('service_options')->nullable();
         });
     }
 
     public function down()
     {
-        Schema::dropIfExists('offline_mall_services');
-        Schema::dropIfExists('offline_mall_service_options');
-        Schema::dropIfExists('offline_mall_service_tax');
-        Schema::dropIfExists('offline_mall_product_service');
-        Schema::dropIfExists('offline_mall_cart_product_service_option');
-        Schema::table('offline_mall_order_products', function ($table) {
+        Schema::dropIfExists('winter_mall_services');
+        Schema::dropIfExists('winter_mall_service_options');
+        Schema::dropIfExists('winter_mall_service_tax');
+        Schema::dropIfExists('winter_mall_product_service');
+        Schema::dropIfExists('winter_mall_cart_product_service_option');
+        Schema::table('winter_mall_order_products', function ($table) {
             $table->dropColumn(['service_options']);
         });
     }

--- a/updates/create_offline_mall_shipping_countries.php
+++ b/updates/create_offline_mall_shipping_countries.php
@@ -7,7 +7,7 @@ class CreateOfflineMallShippingCountries extends Migration
 {
     public function up()
     {
-        Schema::create('offline_mall_shipping_countries', function ($table) {
+        Schema::create('winter_mall_shipping_countries', function ($table) {
             $table->engine = 'InnoDB';
             $table->increments('id')->unsigned();
             $table->integer('shipping_method_id')->unsigned();
@@ -17,6 +17,6 @@ class CreateOfflineMallShippingCountries extends Migration
     
     public function down()
     {
-        Schema::dropIfExists('offline_mall_shipping_countries');
+        Schema::dropIfExists('winter_mall_shipping_countries');
     }
 }

--- a/updates/create_offline_mall_shipping_method_discount.php
+++ b/updates/create_offline_mall_shipping_method_discount.php
@@ -7,7 +7,7 @@ class CreateOfflineMallShippingMethodDiscount extends Migration
 {
     public function up()
     {
-        Schema::create('offline_mall_shipping_method_discount', function ($table) {
+        Schema::create('winter_mall_shipping_method_discount', function ($table) {
             $table->engine = 'InnoDB';
             $table->increments('id')->unsigned();
             $table->integer('shipping_method_id')->unsigned();
@@ -19,6 +19,6 @@ class CreateOfflineMallShippingMethodDiscount extends Migration
     
     public function down()
     {
-        Schema::dropIfExists('offline_mall_shipping_method_discount');
+        Schema::dropIfExists('winter_mall_shipping_method_discount');
     }
 }

--- a/updates/create_offline_mall_shipping_method_rates.php
+++ b/updates/create_offline_mall_shipping_method_rates.php
@@ -7,7 +7,7 @@ class CreateOfflineMallShippingMethodRates extends Migration
 {
     public function up()
     {
-        Schema::create('offline_mall_shipping_method_rates', function ($table) {
+        Schema::create('winter_mall_shipping_method_rates', function ($table) {
             $table->engine = 'InnoDB';
             $table->increments('id')->unsigned();
             $table->integer('shipping_method_id')->unsigned();
@@ -18,6 +18,6 @@ class CreateOfflineMallShippingMethodRates extends Migration
     
     public function down()
     {
-        Schema::dropIfExists('offline_mall_shipping_method_rates');
+        Schema::dropIfExists('winter_mall_shipping_method_rates');
     }
 }

--- a/updates/create_offline_mall_shipping_method_tax.php
+++ b/updates/create_offline_mall_shipping_method_tax.php
@@ -7,7 +7,7 @@ class CreateOfflineMallShippingMethodTax extends Migration
 {
     public function up()
     {
-        Schema::create('offline_mall_shipping_method_tax', function ($table) {
+        Schema::create('winter_mall_shipping_method_tax', function ($table) {
             $table->engine = 'InnoDB';
             $table->increments('id')->unsigned();
             $table->integer('shipping_method_id')->unsigned();
@@ -19,6 +19,6 @@ class CreateOfflineMallShippingMethodTax extends Migration
     
     public function down()
     {
-        Schema::dropIfExists('offline_mall_shipping_method_tax');
+        Schema::dropIfExists('winter_mall_shipping_method_tax');
     }
 }

--- a/updates/create_offline_mall_shipping_methods.php
+++ b/updates/create_offline_mall_shipping_methods.php
@@ -7,7 +7,7 @@ class CreateOfflineMallShippingMethods extends Migration
 {
     public function up()
     {
-        Schema::create('offline_mall_shipping_methods', function ($table) {
+        Schema::create('winter_mall_shipping_methods', function ($table) {
             $table->engine = 'InnoDB';
             $table->increments('id')->unsigned();
             $table->string('name', 255);
@@ -22,6 +22,6 @@ class CreateOfflineMallShippingMethods extends Migration
 
     public function down()
     {
-        Schema::dropIfExists('offline_mall_shipping_methods');
+        Schema::dropIfExists('winter_mall_shipping_methods');
     }
 }

--- a/updates/create_offline_mall_taxes.php
+++ b/updates/create_offline_mall_taxes.php
@@ -7,7 +7,7 @@ class CreateOfflineMallTaxes extends Migration
 {
     public function up()
     {
-        Schema::create('offline_mall_taxes', function ($table) {
+        Schema::create('winter_mall_taxes', function ($table) {
             $table->engine = 'InnoDB';
             $table->increments('id')->unsigned();
             $table->string('name', 255);
@@ -19,6 +19,6 @@ class CreateOfflineMallTaxes extends Migration
 
     public function down()
     {
-        Schema::dropIfExists('offline_mall_taxes');
+        Schema::dropIfExists('winter_mall_taxes');
     }
 }

--- a/updates/create_offline_mall_wishlist_items.php
+++ b/updates/create_offline_mall_wishlist_items.php
@@ -7,7 +7,7 @@ class CreateOfflineMallWishlistItems extends Migration
 {
     public function up()
     {
-        Schema::create('offline_mall_wishlist_items', function ($table) {
+        Schema::create('winter_mall_wishlist_items', function ($table) {
             $table->engine = 'InnoDB';
             $table->increments('id')->unsigned();
             $table->integer('wishlist_id')->index();
@@ -22,6 +22,6 @@ class CreateOfflineMallWishlistItems extends Migration
 
     public function down()
     {
-        Schema::dropIfExists('offline_mall_wishlist_items');
+        Schema::dropIfExists('winter_mall_wishlist_items');
     }
 }

--- a/updates/create_offline_mall_wishlists.php
+++ b/updates/create_offline_mall_wishlists.php
@@ -7,7 +7,7 @@ class CreateOfflineMallWishlists extends Migration
 {
     public function up()
     {
-        Schema::create('offline_mall_wishlists', function ($table) {
+        Schema::create('winter_mall_wishlists', function ($table) {
             $table->engine = 'InnoDB';
             $table->increments('id')->unsigned();
             $table->string('name');
@@ -22,6 +22,6 @@ class CreateOfflineMallWishlists extends Migration
 
     public function down()
     {
-        Schema::dropIfExists('offline_mall_wishlists');
+        Schema::dropIfExists('winter_mall_wishlists');
     }
 }

--- a/updates/database_seeder.php
+++ b/updates/database_seeder.php
@@ -40,10 +40,10 @@ class DatabaseSeeder extends Seeder
         (new PriceCategory([
             'code' => 'old_price',
             'name' => 'Old price',
-        ]))->setTable('offline_mall_price_categories')->save();
+        ]))->setTable('winter_mall_price_categories')->save();
 
         Currency::extend(function () {
-            $this->setTable('offline_mall_currencies');
+            $this->setTable('winter_mall_currencies');
             $this->rules['code'] = str_replace('winter_', 'offline_', $this->rules['code']);
         }, true);
         Currency::create([

--- a/updates/handle_index_table.php
+++ b/updates/handle_index_table.php
@@ -14,6 +14,6 @@ class HandleIndexTable extends Migration
 
     public function down()
     {
-        Schema::dropIfExists('offline_mall_index');
+        Schema::dropIfExists('winter_mall_index');
     }
 }

--- a/updates/migrate_categories_to_belongs_to_many_relation.php
+++ b/updates/migrate_categories_to_belongs_to_many_relation.php
@@ -10,7 +10,7 @@ class MigrateCategoriesToBelongstoManyRelation extends Migration
 {
     public function up()
     {
-        Schema::create('offline_mall_category_product', function ($table) {
+        Schema::create('winter_mall_category_product', function ($table) {
             $table->engine = 'InnoDB';
             $table->increments('id')->unsigned();
             $table->integer('product_id')->unsigned();
@@ -19,11 +19,11 @@ class MigrateCategoriesToBelongstoManyRelation extends Migration
         });
 
         // Migrate products to new structure. Migrate the category sort order as well.
-        $sortOrders = DB::table('offline_mall_category_product_sort_order')->get()->mapWithKeys(function ($item) {
+        $sortOrders = DB::table('winter_mall_category_product_sort_order')->get()->mapWithKeys(function ($item) {
             return [$item->category_id . '-' . $item->product_id => $item->sort_order];
         });
 
-        $products = \DB::table('offline_mall_products')->get();
+        $products = \DB::table('winter_mall_products')->get();
         $products->each(function ($product, $index) use ($sortOrders) {
             if ($product->category_id === null) {
                 return;
@@ -32,24 +32,24 @@ class MigrateCategoriesToBelongstoManyRelation extends Migration
             $orderKey  = $product->category_id . '-' . $product->id;
             $sortOrder = $sortOrders[$orderKey] ?? $index;
 
-            DB::table('offline_mall_category_product')->insert([
+            DB::table('winter_mall_category_product')->insert([
                 'product_id'  => $product->id,
                 'category_id' => $product->category_id,
                 'sort_order'  => $sortOrder,
             ]);
         });
 
-        Schema::table('offline_mall_products', function ($table) {
+        Schema::table('winter_mall_products', function ($table) {
             $table->dropColumn(['category_id']);
         });
 
-        Schema::drop('offline_mall_category_product_sort_order');
+        Schema::drop('winter_mall_category_product_sort_order');
     }
 
     public function down()
     {
-        Schema::dropIfExists('offline_mall_category_product');
-        Schema::table('offline_mall_products', function ($table) {
+        Schema::dropIfExists('winter_mall_category_product');
+        Schema::table('winter_mall_products', function ($table) {
             $table->integer('category_id')->nullable();
         });
     }

--- a/updates/migrate_settings.php
+++ b/updates/migrate_settings.php
@@ -30,7 +30,7 @@ class MigrateSettings extends Migration
     {
         $this->init();
 
-        DB::table('system_settings')->where('item', 'offline_mall_settings')->update(['item' => 'winter_mall_settings']);
+        DB::table('system_settings')->where('item', 'winter_mall_settings')->update(['item' => 'winter_mall_settings']);
 
         $srcPaymentGatewaySettings = GeneralSettings::instance();
         $dstPaymentGatewaySettings = PaymentGatewaySettings::instance();
@@ -85,6 +85,6 @@ class MigrateSettings extends Migration
         }
         ReviewSettings::resetDefault();
 
-        DB::table('system_settings')->where('item', 'winter_mall_settings')->update(['item' => 'offline_mall_settings']);
+        DB::table('system_settings')->where('item', 'winter_mall_settings')->update(['item' => 'winter_mall_settings']);
     }
 }

--- a/updates/remove_description_column_from_order_products.php
+++ b/updates/remove_description_column_from_order_products.php
@@ -9,8 +9,8 @@ class RemoveDescriptionColumnFromOrderProducts extends Migration
 {
     public function up()
     {
-        Schema::table('offline_mall_order_products', function ($table) {
-            if (Schema::hasColumn('offline_mall_order_products', 'description')) {
+        Schema::table('winter_mall_order_products', function ($table) {
+            if (Schema::hasColumn('winter_mall_order_products', 'description')) {
                 $table->dropColumn(['description']);
             }
         });
@@ -18,7 +18,7 @@ class RemoveDescriptionColumnFromOrderProducts extends Migration
 
     public function down()
     {
-        Schema::table('offline_mall_order_products', function ($table) {
+        Schema::table('winter_mall_order_products', function ($table) {
             $table->longText('description')->nullable();
         });
     }

--- a/updates/remove_payment_data_column_from_orders_table.php
+++ b/updates/remove_payment_data_column_from_orders_table.php
@@ -9,8 +9,8 @@ class RemovePaymentDataColumnFromOrdersTable extends Migration
 {
     public function up()
     {
-        Schema::table('offline_mall_orders', function ($table) {
-            if (Schema::hasColumn('offline_mall_orders', 'payment_data')) {
+        Schema::table('winter_mall_orders', function ($table) {
+            if (Schema::hasColumn('winter_mall_orders', 'payment_data')) {
                 $table->dropColumn(['payment_data']);
             }
         });
@@ -18,7 +18,7 @@ class RemovePaymentDataColumnFromOrdersTable extends Migration
 
     public function down()
     {
-        Schema::table('offline_mall_orders', function ($table) {
+        Schema::table('winter_mall_orders', function ($table) {
             $table->mediumText('payment_data')->nullable();
         });
     }

--- a/updates/rename_tables.php
+++ b/updates/rename_tables.php
@@ -18,8 +18,8 @@ class RenameTables extends Migration
     public function up()
     {
         $query = match(config('database.default')) {
-            'sqlite' => 'SELECT name FROM sqlite_master WHERE type="table" AND name LIKE "offline_mall_%"',
-            default => 'SELECT table_name FROM information_schema.tables WHERE table_name LIKE "offline_mall_%"', 
+            'sqlite' => 'SELECT name FROM sqlite_master WHERE type="table" AND name LIKE "winter_mall_%"',
+            default => 'SELECT table_name FROM information_schema.tables WHERE table_name LIKE "winter_mall_%"', 
         };
         $tables = collect(Db::select($query))->map(fn($table) => head((array)$table))->all();
 

--- a/updates/set_default_tax.php
+++ b/updates/set_default_tax.php
@@ -9,7 +9,7 @@ class SetDefaultTax extends Migration
     public function up()
     {
         Tax::extend(function () {
-            $this->setTable('offline_mall_taxes');
+            $this->setTable('winter_mall_taxes');
         }, true);
 
         // Version 1.9.0 introduced a default tax. Let's use the first one as default.

--- a/updates/update_description_short_column_of_product_variants_table.php
+++ b/updates/update_description_short_column_of_product_variants_table.php
@@ -7,7 +7,7 @@ class UpdateDescriptionShortColumnOfProductVariantsTable extends Migration
 {
     public function up()
     {
-        Schema::table('offline_mall_product_variants', function($table)
+        Schema::table('winter_mall_product_variants', function($table)
         {
             $table->text('description_short')->change();
         });
@@ -15,7 +15,7 @@ class UpdateDescriptionShortColumnOfProductVariantsTable extends Migration
 
     public function down()
     {
-        Schema::table('offline_mall_product_variants', function($table)
+        Schema::table('winter_mall_product_variants', function($table)
         {
             $table->string('description_short', 255)->change();
         });

--- a/updates/update_description_short_column_of_products_table.php
+++ b/updates/update_description_short_column_of_products_table.php
@@ -7,7 +7,7 @@ class UpdateDescriptionShortColumnOfProductsTable extends Migration
 {
     public function up()
     {
-        Schema::table('offline_mall_products', function($table)
+        Schema::table('winter_mall_products', function($table)
         {
             $table->text('description_short')->change();
         });
@@ -15,7 +15,7 @@ class UpdateDescriptionShortColumnOfProductsTable extends Migration
 
     public function down()
     {
-        Schema::table('offline_mall_products', function($table)
+        Schema::table('winter_mall_products', function($table)
         {
             $table->string('description_short', 255)->change();
         });

--- a/updates/update_jsonable_columns_to_mediumtext.php
+++ b/updates/update_jsonable_columns_to_mediumtext.php
@@ -10,12 +10,12 @@ class UpdateJsonableColumnsToMediumtext extends Migration
 {
     public function up()
     {
-        Schema::table('offline_mall_payments_log', function (Blueprint $table) {
+        Schema::table('winter_mall_payments_log', function (Blueprint $table) {
             $table->mediumText('payment_method')->change();
             $table->mediumText('data')->change();
             $table->longText('order_data')->change();
         });
-        Schema::table('offline_mall_orders', function (Blueprint $table) {
+        Schema::table('winter_mall_orders', function (Blueprint $table) {
             $table->mediumText('currency')->change();
             $table->mediumText('billing_address')->change();
             $table->mediumText('shipping_address')->change();
@@ -24,7 +24,7 @@ class UpdateJsonableColumnsToMediumtext extends Migration
             $table->mediumText('payment')->change();
             $table->mediumText('payment_data')->change();
         });
-        Schema::table('offline_mall_order_products', function (Blueprint $table) {
+        Schema::table('winter_mall_order_products', function (Blueprint $table) {
             $table->mediumText('property_values')->change();
             $table->longText('custom_field_values')->change();
             $table->mediumText('taxes')->change();

--- a/updates/use_text_columns_for_payment_log.php
+++ b/updates/use_text_columns_for_payment_log.php
@@ -9,7 +9,7 @@ class UseTextColumnsForPaymentLog extends Migration
 {
     public function up()
     {
-        Schema::table('offline_mall_payments_log', function ($table) {
+        Schema::table('winter_mall_payments_log', function ($table) {
             $table->text('payment_method')->change();
             $table->text('message')->change();
         });

--- a/updates/use_text_columns_for_variant_names.php
+++ b/updates/use_text_columns_for_variant_names.php
@@ -9,7 +9,7 @@ class UseTextColumnsForVariantNames extends Migration
 {
     public function up()
     {
-        Schema::table('offline_mall_order_products', function ($table) {
+        Schema::table('winter_mall_order_products', function ($table) {
             $table->text('variant_name')->change();
         });
     }

--- a/updates/version.yaml
+++ b/updates/version.yaml
@@ -1,49 +1,49 @@
 1.0.0:
     - 'First public release'
-    - create_offline_mall_products.php
-    - create_offline_mall_product_variants.php
-    - create_offline_mall_product_accessory.php
-    - create_offline_mall_custom_fields.php
-    - create_offline_mall_custom_field_options.php
-    - create_offline_mall_categories.php
-    - create_offline_mall_taxes.php
-    - create_offline_mall_product_tax.php
-    - create_offline_mall_carts.php
-    - create_offline_mall_cart_products.php
-    - create_offline_mall_shipping_methods.php
-    - create_offline_mall_shipping_method_tax.php
-    - create_offline_mall_country_tax.php
-    - create_offline_mall_shipping_method_rates.php
-    - create_offline_mall_cart_custom_field_value.php
-    - create_offline_mall_discounts.php
-    - create_offline_mall_cart_discount.php
-    - create_offline_mall_orders.php
-    - create_offline_mall_order_products.php
-    - create_offline_mall_addresses.php
-    - create_offline_mall_customers.php
-    - create_offline_mall_shipping_countries.php
-    - create_offline_mall_payments_log.php
-    - create_offline_mall_payment_methods.php
-    - create_offline_mall_payment_method_tax.php
-    - create_offline_mall_product_custom_field.php
-    - create_offline_mall_properties.php
-    - create_offline_mall_property_values.php
-    - create_offline_mall_order_states.php
-    - create_offline_mall_brands.php
-    - create_offline_mall_image_sets.php
-    - create_offline_mall_property_property_group.php
-    - create_offline_mall_property_groups.php
-    - create_offline_mall_category_property_group.php
-    - create_offline_mall_customer_groups.php
-    - create_offline_mall_customer_group_prices.php
-    - create_offline_mall_price_categories.php
-    - create_offline_mall_prices.php
-    - create_offline_mall_product_prices.php
-    - create_offline_mall_category_product_sort_order.php
-    - create_offline_mall_currencies.php
+    - create_winter_mall_products.php
+    - create_winter_mall_product_variants.php
+    - create_winter_mall_product_accessory.php
+    - create_winter_mall_custom_fields.php
+    - create_winter_mall_custom_field_options.php
+    - create_winter_mall_categories.php
+    - create_winter_mall_taxes.php
+    - create_winter_mall_product_tax.php
+    - create_winter_mall_carts.php
+    - create_winter_mall_cart_products.php
+    - create_winter_mall_shipping_methods.php
+    - create_winter_mall_shipping_method_tax.php
+    - create_winter_mall_country_tax.php
+    - create_winter_mall_shipping_method_rates.php
+    - create_winter_mall_cart_custom_field_value.php
+    - create_winter_mall_discounts.php
+    - create_winter_mall_cart_discount.php
+    - create_winter_mall_orders.php
+    - create_winter_mall_order_products.php
+    - create_winter_mall_addresses.php
+    - create_winter_mall_customers.php
+    - create_winter_mall_shipping_countries.php
+    - create_winter_mall_payments_log.php
+    - create_winter_mall_payment_methods.php
+    - create_winter_mall_payment_method_tax.php
+    - create_winter_mall_product_custom_field.php
+    - create_winter_mall_properties.php
+    - create_winter_mall_property_values.php
+    - create_winter_mall_order_states.php
+    - create_winter_mall_brands.php
+    - create_winter_mall_image_sets.php
+    - create_winter_mall_property_property_group.php
+    - create_winter_mall_property_groups.php
+    - create_winter_mall_category_property_group.php
+    - create_winter_mall_customer_groups.php
+    - create_winter_mall_customer_group_prices.php
+    - create_winter_mall_price_categories.php
+    - create_winter_mall_prices.php
+    - create_winter_mall_product_prices.php
+    - create_winter_mall_category_product_sort_order.php
+    - create_winter_mall_currencies.php
     - allow_non_unique_emails_for_rainlab_user.php
     - add_customer_group_id_to_rainlab_users.php
-    - create_offline_mall_notifications.php
+    - create_winter_mall_notifications.php
     - database_seeder.php
 1.0.2:
     - Fixed event handler for welcome email
@@ -136,7 +136,7 @@
     - Added italian translations (thanks to @marcomessa)
 1.2.0:
     - Customers can now re-use payment methods (like Credit cards)
-    - create_offline_mall_customer_payment_methods.php
+    - create_winter_mall_customer_payment_methods.php
 1.2.1:
     - Minor bug fixes and optimizations
     - remove_description_column_from_order_products.php
@@ -198,13 +198,13 @@
     - add_embeds_column_to_products_table.php
 1.4.0:
     - Added Wishlists feature
-    - create_offline_mall_wishlists.php
-    - create_offline_mall_wishlist_items.php
+    - create_winter_mall_wishlists.php
+    - create_winter_mall_wishlist_items.php
 1.4.1:
     - "!!! Added terms and conditions checkbox to signup form. If you manually modified the signup form partials make sure to add the checkbox as well since it is being validated as required by default. (see https://tinyurl.com/yyanm7eo)"
 1.5.0:
     - Added Services feature (e. g. extended warranty, on-site installation)
-    - create_offline_mall_services.php
+    - create_winter_mall_services.php
 1.5.1:
     - "!!! There is now a changelog documenting breaking changes with every future release. Make sure to check it out: https://bit.ly/2kCk2F9"
 1.5.2:
@@ -213,7 +213,7 @@
     - Another bugfix release
 1.6.0:
     - Added Reviews. Speaking of reviews, did you already add a review for this plugin ;-)? https://octobercms.com/plugin/offline-mall
-    - create_offline_mall_reviews.php
+    - create_winter_mall_reviews.php
 1.6.1:
     - "Bugfix release. Don't forget to check out the new changelog for updates to 1.6.0: https://offline-gmbh.github.io/oc-mall-plugin/changelog/1.6.0.html"
 1.6.2:
@@ -377,7 +377,7 @@
     - 'Added support for PHP 8 (see changelog: https://offline-gmbh.github.io/oc-mall-plugin/changelog/1.14.0.html)'
 1.14.1:
     - 'Added possibility to apply discounts when a certain shipping method is selected (credits to @inalto)'
-    - create_offline_mall_shipping_method_discount.php
+    - create_winter_mall_shipping_method_discount.php
 1.14.2:
     - 'Various minor bugfixes and improvements'
 1.14.3:


### PR DESCRIPTION
Replace the offline_mall table prefix with winter_mall across seeders and migration/update files. All Schema::create/Schema::table/Schema::drop checks, model setTable calls, and belongsToMany/pivot table names were updated to use winter_mall_*. Notification seeders/updates were adjusted to set the notification table and rules mapping. This changeset standardizes the DB table naming (creates/drops/columns/relations) to the new winter_mall prefix and updates related seeders and migrations accordingly.

<!--
Pull Requests without a descriptive title, thorough description, or tests will be closed.

Please include the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc. The more detail the better.

If documentation improvements are required, you are expected to make a simultaneous pull request to https://github.com/wintercms/docs to update the documentation
-->